### PR TITLE
Add support for receiving youtubeApiKey and rendering Youtube Videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.2.0] - 2019-02-22
 
+### Changed
+- Add support for receiving youtubeApiKey and rendering Youtube Videos
+
 ## [1.1.7] - 2019-01-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.2.0] - 2019-02-22
+
 ## [1.1.7] - 2019-01-09
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "butik",
-  "version": "1.1.7",
+  "version": "1.2.0",
   "title": "VTEX Butik",
   "description": "VTEX components for store front",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/butik",
-  "version": "1.1.7",
+  "version": "1.2.0",
   "description": "VTEX components for store front",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/react/components/Carousel/index.js
+++ b/react/components/Carousel/index.js
@@ -44,7 +44,7 @@ class Carousel extends Component {
       slides.forEach((slide, i) => {
         if (slide.type === 'video') {
           this.isVideo[i] = true
-          Video.getThumbUrl(slide.src, slide.thumbWidth).then(this.getThumb)
+          Video.getThumbUrl(slide.src, slide.thumbWidth, slide.apiKey).then(this.getThumb)
         } else this.getThumb(slide.thumbUrl)
       })
   }
@@ -141,6 +141,7 @@ class Carousel extends Component {
             setThumb={this.setVideoThumb(i)}
             playing={i === this.state.activeIndex}
             id={i}
+            apiKey={slide.apiKey}
           />
         )
       default:

--- a/react/components/Video/Youtube.js
+++ b/react/components/Video/Youtube.js
@@ -106,14 +106,13 @@ Youtube.propTypes = {
   url: PropTypes.string.isRequired,
   id: PropTypes.number.isRequired, // Unique ID for iframe title
   setThumb: PropTypes.func,
-  thumbWidth: PropTypes.number,
   className: PropTypes.string,
   loop: PropTypes.bool,
   autoplay: PropTypes.bool,
   width: PropTypes.number,
   height: PropTypes.number,
   playing: PropTypes.bool,
-  apiKey: PropTypes.string,
+  apiKey: PropTypes.string.isRequired, // API key necessary for youtube requests
 }
 
 Youtube.defaultProps = {

--- a/react/components/Video/Youtube.js
+++ b/react/components/Video/Youtube.js
@@ -1,15 +1,11 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-const youtubeApiKey = null
-
-// TODO: Youtube Component disabled until settings update and backend update to support video
-// Author: @samuraiexx
 
 class Youtube extends Component {
-  static getThumbUrl = url =>
+  static getThumbUrl = (url, apiKey) =>
     new Promise(resolve => {
       const videoId = Youtube.extractVideoID(url)
-      const getUrl = `https://www.googleapis.com/youtube/v3/videos?part=snippet&id=${videoId}&key=${youtubeApiKey}`
+      const getUrl = `https://www.googleapis.com/youtube/v3/videos?part=snippet&id=${videoId}&key=${apiKey}`
       fetch(getUrl)
         .then(responseonse => {
           return responseonse.json()
@@ -30,7 +26,7 @@ class Youtube extends Component {
     const { loop, autoplay, title, url } = this.props
     const params = `autoplay=${autoplay}&loop=${loop}&title=${title}&enablejsapi=1&iv_load_policy=3&modestbranding=1`
     const videoId = Youtube.extractVideoID(url)
-    const getUrl = `https://www.googleapis.com/youtube/v3/videos?part=snippet&id=${videoId}&key=${youtubeApiKey}`
+    const getUrl = `https://www.googleapis.com/youtube/v3/videos?part=snippet&id=${videoId}&key=${props.apiKey}`
 
     this.iframeRef = React.createRef()
 
@@ -59,10 +55,13 @@ class Youtube extends Component {
   }
 
   static extractVideoID = url => {
-    const regExp = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/
-    const match = url.match(regExp)
-    if (match && match[7].length === 11) return match[7]
-    return null
+    const regExp = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#\&\?]*).*/
+    var match = url.match(regExp)
+    if (match && match[7].length == 11){
+        return match[7];
+    }
+    console.error('Could not extract youtube video ID')
+    return ''
   }
 
   componentDidMount() {

--- a/react/components/Video/Youtube.js
+++ b/react/components/Video/Youtube.js
@@ -23,10 +23,10 @@ class Youtube extends Component {
 
     this.state = { iframe: {} }
 
-    const { loop, autoplay, title, url } = this.props
-    const params = `autoplay=${autoplay}&loop=${loop}&title=${title}&enablejsapi=1&iv_load_policy=3&modestbranding=1`
+    const { loop, autoplay, url, apiKey } = this.props
+    const params = `autoplay=${autoplay}&loop=${loop}&enablejsapi=1&iv_load_policy=3&modestbranding=1`
     const videoId = Youtube.extractVideoID(url)
-    const getUrl = `https://www.googleapis.com/youtube/v3/videos?part=snippet&id=${videoId}&key=${props.apiKey}`
+    const getUrl = `https://www.googleapis.com/youtube/v3/videos?part=snippet&id=${videoId}&key=${apiKey}`
 
     this.iframeRef = React.createRef()
 
@@ -110,11 +110,10 @@ Youtube.propTypes = {
   className: PropTypes.string,
   loop: PropTypes.bool,
   autoplay: PropTypes.bool,
-  showTitle: PropTypes.bool,
   width: PropTypes.number,
   height: PropTypes.number,
   playing: PropTypes.bool,
-  title: PropTypes.string,
+  apiKey: PropTypes.string,
 }
 
 Youtube.defaultProps = {
@@ -122,7 +121,6 @@ Youtube.defaultProps = {
   autoplay: false,
   width: null,
   height: null,
-  title: false,
   className: '',
 }
 

--- a/react/components/Video/Youtube.js
+++ b/react/components/Video/Youtube.js
@@ -56,8 +56,8 @@ class Youtube extends Component {
 
   static extractVideoID = url => {
     const regExp = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#\&\?]*).*/
-    var match = url.match(regExp)
-    if (match && match[7].length == 11){
+    const match = url.match(regExp)
+    if (match && match[7].length == 11) {
         return match[7];
     }
     console.error('Could not extract youtube video ID')

--- a/react/components/Video/index.js
+++ b/react/components/Video/index.js
@@ -1,19 +1,25 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Vimeo from './Vimeo'
+import Youtube from './Youtube'
 
 class Video extends Component {
-  static getThumbUrl(url, thumbWidth) {
+  static getThumbUrl(url, thumbWidth, apiKey) {
     if (url.search('vimeo') !== -1) {
       return Vimeo.getThumbUrl(url, thumbWidth)
+    }
+    if (url.search('youtube') !== -1) {
+      return Youtube.getThumbUrl(url, apiKey)
     }
   }
 
   render() {
     const { url } = this.props
-
     if (url.search('vimeo') !== -1) {
       return <Vimeo {...this.props} />
+    }
+    if (url.search('youtube') !== -1) {
+      return <Youtube {...this.props} />
     }
   }
 }
@@ -30,6 +36,7 @@ Video.propTypes = {
   className: PropTypes.string,
   /** Dynamic prop that pauses and plays the video */
   play: PropTypes.bool,
+  apiKey: PropTypes.string,
 }
 
 export default Video


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Add apiKey prop to `Youtube` and `Video` components. This is necessary for video URLs (e.g. Youtube) which needs an API key.

Also removes the `title` prop since it has no use in the [Youtube API for list](https://developers.google.com/youtube/v3/docs/videos/list)

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Add support for videos in the inStore

#### How should this be manually tested?

#### Screenshots or example usage
Example of use in the inStore

![image](https://user-images.githubusercontent.com/3064099/53093637-b97bac80-34f6-11e9-8d2a-89ee878a0ba8.png)


#### Types of changes
- [ ] Refactor (non-breaking change which improves security, performance or maintainability)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
