### PR TITLE
Increase fault tolerance for video rendering in Carousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.2.1] - 2019-03-08
+
 ### Fixed
 - Increase fault tolerance for video rendering in Carousel
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Increase fault tolerance for video rendering in Carousel
+
 ## [1.2.0] - 2019-02-22
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "butik",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "title": "VTEX Butik",
   "description": "VTEX components for store front",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/butik",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "VTEX components for store front",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/react/components/Video/Youtube.js
+++ b/react/components/Video/Youtube.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 class Youtube extends Component {
   static getThumbUrl = (url, apiKey) =>
-    new Promise(resolve => {
+    new Promise((resolve, reject) => {
       const videoId = Youtube.extractVideoID(url)
       const getUrl = `https://www.googleapis.com/youtube/v3/videos?part=snippet&id=${videoId}&key=${apiKey}`
       fetch(getUrl)
@@ -11,7 +11,10 @@ class Youtube extends Component {
           return responseonse.json()
         })
         .then(response => {
-          if (response.items.length === 0) return
+          if (response.items.length === 0) {
+            reject(`No video found with URL: ${url} and apiKey: ${apiKey}`)
+            return
+          }
           response = response.items[0].snippet
 
           resolve(response.thumbnails.default.url)
@@ -55,10 +58,10 @@ class Youtube extends Component {
   }
 
   static extractVideoID = url => {
-    const regExp = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#\&\?]*).*/
+    const regExp = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/
     const match = url.match(regExp)
-    if (match && match[7].length == 11) {
-        return match[7];
+    if (match && match[7].length === 11) {
+      return match[7]
     }
     console.error('Could not extract youtube video ID')
     return ''

--- a/react/components/Video/index.js
+++ b/react/components/Video/index.js
@@ -11,6 +11,7 @@ class Video extends Component {
     if (url.search('youtube') !== -1) {
       return Youtube.getThumbUrl(url, apiKey)
     }
+    return Promise.reject(`Unsupported video url format, ${url}`)
   }
 
   render() {
@@ -21,6 +22,7 @@ class Video extends Component {
     if (url.search('youtube') !== -1) {
       return <Youtube {...this.props} />
     }
+    return null
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Increase the fault tolerance of the video carousel. Components which have invalid URL's, receive errors while trying to fetch some data and other errors should not be rendered.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The non-rendering of faulty video components enable the Product Page to still be functional even with wrongly formatted videos in their configuration.
#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (a non-breaking change which improves security, performance or maintainability)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
