### PR TITLE
Fix loaderClass warning from ProductPrice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove loaderClass property from DOM elements
 
 ## [1.3.1] - 2019-09-09
 

--- a/react/components/ProductPrice/index.js
+++ b/react/components/ProductPrice/index.js
@@ -160,46 +160,46 @@ class Price extends Component {
   }
 }
 
-Price.Loader = (loaderProps = {}) => (
-  <div
-    className={classNames(
-      'vtex-price vtex-price-loader',
-      loaderProps.loaderClass
-    )}>
-    <ContentLoader
-      style={{
-        width: '100%',
-        height: '100%',
-      }}
-      width={300}
-      height={70}
-      preserveAspectRatio="xMinYMin meet"
-      {...loaderProps}>
-      <rect
-        height="0.75em"
-        width="50%"
-        x="25%"
-        {...loaderProps['vtex-price-list__container--loader']}
-      />
-      <rect {...loaderProps['vtex-price-selling__label--loader']} />
-      <rect
-        height="1em"
-        width="70%"
-        x="15%"
-        y="1.25em"
-        {...loaderProps['vtex-price-selling--loader']}
-      />
-      <rect
-        height="0.75em"
-        width="80%"
-        x="10%"
-        y="2.75em"
-        {...loaderProps['vtex-price-installments--loader']}
-      />
-      <rect {...loaderProps['vtex-price-savings--loader']} />
-    </ContentLoader>
-  </div>
-)
+Price.Loader = (loaderProps = {}) => {
+  const { loaderClass, ...filteredLoaderProps } = loaderProps
+
+  return (
+    <div className={classNames('vtex-price vtex-price-loader', loaderClass)}>
+      <ContentLoader
+        style={{
+          width: '100%',
+          height: '100%',
+        }}
+        width={300}
+        height={70}
+        preserveAspectRatio="xMinYMin meet"
+        {...filteredLoaderProps}>
+        <rect
+          height="0.75em"
+          width="50%"
+          x="25%"
+          {...filteredLoaderProps['vtex-price-list__container--loader']}
+        />
+        <rect {...filteredLoaderProps['vtex-price-selling__label--loader']} />
+        <rect
+          height="1em"
+          width="70%"
+          x="15%"
+          y="1.25em"
+          {...filteredLoaderProps['vtex-price-selling--loader']}
+        />
+        <rect
+          height="0.75em"
+          width="80%"
+          x="10%"
+          y="2.75em"
+          {...filteredLoaderProps['vtex-price-installments--loader']}
+        />
+        <rect {...filteredLoaderProps['vtex-price-savings--loader']} />
+      </ContentLoader>
+    </div>
+  )
+}
 
 Price.Loader.displayName = 'Price.Loader'
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix warning from **ProductPrice** component

- [Clubhouse](https://app.clubhouse.io/vtex/story/27125/remover-warning-de-loaderclass-da-busca)

#### How should this be manually tested?
1. Access locally the **butik** _docz_
2. Access **ProductPrice** page
3. Open the console
4. Open the component editor
5. Change the selling price to null
6. Check the console if there is a `React does not recognize the "loaderClass" prop on a DOM element` warning

#### Screenshots or example usage
From [inStore](https://github.com/vtex/checkout-instore): Just search something and then

![image](https://user-images.githubusercontent.com/8717661/69670625-13effd80-1073-11ea-9971-1aea555f3bfb.png)

#### Types of changes
- [x] Refactor (non-breaking change which improves security, performance or maintainability)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
