### PR TITLE
Fix initial state not being correctly set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Initial state not being correctly set
 
 ## [1.3.3] - 2019-12-30
 ### Changed

--- a/react/components/SKUSelector/index.js
+++ b/react/components/SKUSelector/index.js
@@ -170,7 +170,7 @@ class SKUSelector extends PureComponent {
       })
     })
 
-    if (initialState && stateMachine[initialState])
+    if (initialState && stateMachine.states[initialState])
       stateMachine.initial = initialState
 
     return Machine(stateMachine)


### PR DESCRIPTION
Small fix, the guard to check if the passed initial state does really exists in the state machine was incorrectly looking at the root level of the machine when it should look at the `states` property.